### PR TITLE
Retry deploy process if commit fails due to conflict

### DIFF
--- a/index.js
+++ b/index.js
@@ -49,107 +49,112 @@ async function getContents(repo, repoPath, ref) {
 
 async function run(callback) {
   try {
-    const repo = await makeRepo(
-      core.getInput("repository"),
-      core.getInput("token")
-    );
-
-    const versionToSet = core.getInput("new-version");
-    const repoPath = core.getInput("path");
-    const ref = core.getInput("ref");
     const retryCount = parseInt(core.getInput("retryCount") ?? 12);
-
-    if (!versionToSet) {
-      throw new Error("new-version is not set to anything, cannot update git");
-    }
-
-    console.log(`Updating ${repoPath} to version ${versionToSet}`);
-
-    let contents, mode, commit, commitHash;
-    try {
-      ({ contents, mode, commit, commitHash } = await getContents(
-        repo,
-        repoPath,
-        ref
-      ));
-    } catch (err) {
-      console.log(util.inspect(err));
-      throw new Error(
-        `could not read contents of configured gitops file, please make sure ${repoPath} exists!`
-      );
-    }
-
-    // update the contents with the new data
-    let newData;
-    const existingData = _get(contents, core.getInput("field"));
-    if (existingData.indexOf(":") !== -1) {
-      newData =
-        existingData.substr(0, existingData.indexOf(":")) + ":" + versionToSet;
-    } else {
-      newData = versionToSet;
-    }
-
-    if (newData == existingData) {
-      console.log("nothing to commit, deploy is already set on gitops repo.");
-      return core.setOutput("commit", commitHash);
-    }
-
-    const newContents = _set(contents, core.getInput("field"), newData);
-
-    console.log(newContents);
-
-    const newFile = newContents
-      .map((c) => yaml.safeDump(c, { noArrayIndent: true }))
-      .join("\n---\n");
-
-    const newTree = [
-      {
-        path: repoPath,
-        mode: mode,
-        content: Buffer.from(newFile),
-      },
-    ];
-
-    newTree.base = commit.tree;
-
-    const newTreeHash = await util.promisify(repo.createTree)(newTree);
-
-    console.log("created tree with hash:", newTreeHash);
-
-    var newCommitHash = await util.promisify(repo.saveAs)("commit", {
-      tree: newTreeHash,
-      author: {
-        name: "GitOps CI",
-        email: "ci@example.com",
-        date: { seconds: Math.floor(Date.now() / 1000), offset: 0 },
-      },
-      committer: {
-        name: "GitOps CI",
-        email: "ci@example.com",
-        date: { seconds: Math.floor(Date.now() / 1000), offset: 0 },
-      },
-      parents: [commitHash],
-      message: `${
-        process.env["GITHUB_REPOSITORY"].split("/")[1]
-      }: new deploy (${versionToSet})`,
-    });
-
-    console.log("created commit with hash:", newCommitHash);
     await promiseRetry(
       async function (retry) {
+        const repo = await makeRepo(
+          core.getInput("repository"),
+          core.getInput("token")
+        );
+
+        const versionToSet = core.getInput("new-version");
+        const repoPath = core.getInput("path");
+        const ref = core.getInput("ref");
+
+        if (!versionToSet) {
+          throw new Error(
+            "new-version is not set to anything, cannot update git"
+          );
+        }
+
+        console.log(`Updating ${repoPath} to version ${versionToSet}`);
+
+        let contents, mode, commit, commitHash;
+        try {
+          ({ contents, mode, commit, commitHash } = await getContents(
+            repo,
+            repoPath,
+            ref
+          ));
+        } catch (err) {
+          console.log(util.inspect(err));
+          throw new Error(
+            `could not read contents of configured gitops file, please make sure ${repoPath} exists!`
+          );
+        }
+
+        // update the contents with the new data
+        let newData;
+        const existingData = _get(contents, core.getInput("field"));
+        if (existingData.indexOf(":") !== -1) {
+          newData =
+            existingData.substr(0, existingData.indexOf(":")) +
+            ":" +
+            versionToSet;
+        } else {
+          newData = versionToSet;
+        }
+
+        if (newData == existingData) {
+          console.log(
+            "nothing to commit, deploy is already set on gitops repo."
+          );
+          return core.setOutput("commit", commitHash);
+        }
+
+        const newContents = _set(contents, core.getInput("field"), newData);
+
+        console.log(newContents);
+
+        const newFile = newContents
+          .map((c) => yaml.safeDump(c, { noArrayIndent: true }))
+          .join("\n---\n");
+
+        const newTree = [
+          {
+            path: repoPath,
+            mode: mode,
+            content: Buffer.from(newFile),
+          },
+        ];
+
+        newTree.base = commit.tree;
+
+        const newTreeHash = await util.promisify(repo.createTree)(newTree);
+
+        console.log("created tree with hash:", newTreeHash);
+
+        var newCommitHash = await util.promisify(repo.saveAs)("commit", {
+          tree: newTreeHash,
+          author: {
+            name: "GitOps CI",
+            email: "ci@example.com",
+            date: { seconds: Math.floor(Date.now() / 1000), offset: 0 },
+          },
+          committer: {
+            name: "GitOps CI",
+            email: "ci@example.com",
+            date: { seconds: Math.floor(Date.now() / 1000), offset: 0 },
+          },
+          parents: [commitHash],
+          message: `${
+            process.env["GITHUB_REPOSITORY"].split("/")[1]
+          }: new deploy (${versionToSet})`,
+        });
+
+        console.log("created commit with hash:", newCommitHash);
         try {
           await util.promisify(repo.updateRef)(ref, newCommitHash);
         } catch (error) {
-          console.log("commit failed, retrying", error)
-          retry();
+          console.log("commit failed, retrying:", error);
+          return retry();
         }
+
+        console.log("updated ref");
+        core.setOutput("commit", newCommitHash);
       },
       { minTimeout: 1000, retries: retryCount }
     );
-
-    console.log("updated ref");
-
-    core.setOutput("commit", newCommitHash);
   } catch (error) {
     core.setFailed(util.inspect(error));
   }

--- a/index.js
+++ b/index.js
@@ -49,7 +49,7 @@ async function getContents(repo, repoPath, ref) {
 
 async function run(callback) {
   try {
-    const retryCount = parseInt(core.getInput("retryCount") ?? 12);
+    const retryCount = parseInt(core.getInput("retryCount") ?? 2);
     await promiseRetry(
       async function (retry) {
         const repo = await makeRepo(

--- a/index.js
+++ b/index.js
@@ -145,13 +145,12 @@ async function run(callback) {
         console.log("created commit with hash:", newCommitHash);
         try {
           await util.promisify(repo.updateRef)(ref, newCommitHash);
+          console.log("updated ref");
+          core.setOutput("commit", newCommitHash);
         } catch (error) {
           console.log("commit failed, retrying:", error);
           return retry();
         }
-
-        console.log("updated ref");
-        core.setOutput("commit", newCommitHash);
       },
       { minTimeout: 1000, retries: retryCount }
     );


### PR DESCRIPTION
Building on Omer's change - the retry worked as expected, but if the final commit fails due to a conflict a new commit needs to be prepared. This change wraps the entire process in the retry function.